### PR TITLE
Ensure teardown methods are always called.

### DIFF
--- a/shoulda.js
+++ b/shoulda.js
@@ -243,14 +243,18 @@ scope.Tests = {
     var testScope = {};
 
     try {
-      for (var i = 0; i < contexts.length; i++) {
-        if (contexts[i].setupMethod)
-          contexts[i].setupMethod.methodBody.apply(testScope);
+      try {
+        for (var i = 0; i < contexts.length; i++) {
+          if (contexts[i].setupMethod)
+            contexts[i].setupMethod.methodBody.apply(testScope);
+        }
+        testMethod.methodBody.apply(testScope);
       }
-      testMethod.methodBody.apply(testScope);
-      for (var i = 0; i < contexts.length; i++) {
-        if (contexts[i].tearDownMethod)
-          contexts[i].tearDownMethod.methodBody.apply(testScope);
+      finally {
+        for (var i = 0; i < contexts.length; i++) {
+          if (contexts[i].tearDownMethod)
+            contexts[i].tearDownMethod.methodBody.apply(testScope);
+        }
       }
     } catch(exception) {
       failureMessage = exception.toString();


### PR DESCRIPTION
While setting up PhantomJS testing for Vimium, I got very confused about why some errors were occurring -- it turned out that exceptions thrown in an earlier test were causing subsequent ones to fail because the teardown method was not called.
